### PR TITLE
Add Vitest setup and Tabs test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,17 +8,21 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "vitest"
   },
   "dependencies": {
+    "date-fns": "^3.3.1",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "socket.io-client": "^4.7.4",
-    "date-fns": "^3.3.1"
+    "socket.io-client": "^4.7.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
@@ -27,10 +31,12 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
+    "jsdom": "^26.1.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^3.2.3"
   }
 }

--- a/src/components/ui/__tests__/Tabs.test.tsx
+++ b/src/components/ui/__tests__/Tabs.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../Tabs';
+
+describe('Tabs', () => {
+  it('switches content when trigger is clicked', async () => {
+    render(
+      <Tabs defaultValue="tab1">
+        <TabsList>
+          <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+          <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">Content 1</TabsContent>
+        <TabsContent value="tab2">Content 2</TabsContent>
+      </Tabs>
+    );
+
+    expect(screen.getByText('Content 1')).toBeInTheDocument();
+    expect(screen.queryByText('Content 2')).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('tab', { name: /tab 2/i }));
+
+    expect(screen.getByText('Content 2')).toBeInTheDocument();
+    expect(screen.queryByText('Content 1')).not.toBeInTheDocument();
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+  },
 });


### PR DESCRIPTION
## Summary
- install Vitest and React Testing Library dev dependencies
- configure Vitest in `vite.config.ts`
- add `src/setupTests.ts` for RTL setup
- create a Tabs component test
- expose `npm test` script

## Testing
- `npm test --silent` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7e0f27c8326942722cac5e70814