### PR TITLE
Fix spelling in advanced-features docs

### DIFF
--- a/src/docs/advanced-features-specifications.md
+++ b/src/docs/advanced-features-specifications.md
@@ -1690,7 +1690,7 @@ L'espace collaboratif "TeamSpace" offre aux équipes internes des clients un env
     // Contenu spécifique au type
   },
   source: {
-    type: "string", // "upload", "preveris", "external"
+    type: "string", // "upload", "Prévéris", "external"
     reference: "string" // ID ou URL de référence
   },
   permissions: {


### PR DESCRIPTION
## Summary
- fix spelling of the `Prévéris` source type in advanced features specs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846e7e6b9d483268e5b0c7e0904e237